### PR TITLE
Support nonce for CSP

### DIFF
--- a/src/Html.js
+++ b/src/Html.js
@@ -10,7 +10,8 @@ const Html = ({
   initialState,
   headElement,
   bodyBottomElement,
-  htmlTagAttrs = {}
+  htmlTagAttrs = {},
+  inlineStateNonce
 }) => {
   return (
     <html {...htmlTagAttrs}>
@@ -21,6 +22,7 @@ const Html = ({
           dangerouslySetInnerHTML={{ __html: content }}
         />
         <script
+          nonce={inlineStateNonce}
           dangerouslySetInnerHTML={{
             __html: `window.${REHYDRATION_STATE_DATA_KEY}=${JSON.stringify(
               initialState

--- a/src/createServerRender.js
+++ b/src/createServerRender.js
@@ -91,6 +91,7 @@ export default function createServerRender({
               ? bodyBottomElement({ req })
               : null
           }
+          inlineStateNonce={req.nonce}
         />
       );
 


### PR DESCRIPTION
Make `Html` component able to render `inline initial state` with `nonce` attribute.

### How it works? ###

Server renderer will try to get nonce hash from `req.nonce` and render the inline initial state block with attribute `nonce={req.nonce}`.