### PR TITLE
Use all as the default value of errorPolicy of watchQuery

### DIFF
--- a/src/clientRender.js
+++ b/src/clientRender.js
@@ -26,6 +26,9 @@ export default function clientRender(appElement, inMemoryCacheConfig) {
       window[REHYDRATION_STATE_DATA_KEY]
     ),
     defaultOptions: {
+      watchQuery: {
+        errorPolicy: "all"
+      },
       query: {
         errorPolicy: "all"
       },

--- a/src/createServerRender.js
+++ b/src/createServerRender.js
@@ -72,6 +72,9 @@ export default function createServerRender({
       }),
       cache: new InMemoryCache(),
       defaultOptions: {
+        watchQuery: {
+          errorPolicy: "all"
+        },
         query: {
           errorPolicy: "all"
         },


### PR DESCRIPTION
> Note: The <Query /> React component uses Apollo Client's watchQuery function. To set defaultOptions when using the <Query /> component, make sure to set them under the defaultOptions.watchQuery property.

ref: https://www.apollographql.com/docs/react/api/apollo-client/