### PR TITLE
Feat: transform appElement into a render function

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ export default [
     method: 'get', // default is get if this field is not defined
     path: '/home',
     htmlTagAttrs: {lang: 'en-GB'},
-    appElement: <HomeApp />,
-    headElement: ({ req }) => (<title>Home</title>),
-    bodyBottomElement: ({ req }) => (<script src="/static/bundle.js"></script>)
+    appElement: ({ req }) => <HomeApp />,
+    headElement: ({ req }) => <title>Home</title>,
+    bodyBottomElement: ({ req }) => <script src="/static/bundle.js"></script>
   }
 ]
 ```
@@ -134,10 +134,10 @@ Hydrate the universal app container (reuse server-side generated HTML content an
 |         field      |                                                    description                                                                                                      |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | path               | Same as Express middleware [path argument](https://expressjs.com/en/api.html#path-examples)                                                                         | 
-| appElement         | The React element you want to render into the app container when given path is matched                                                                              |
+| appElement         | A function called with current request that returns a React element you want to render into the app container when the given path is matched                                                                              |
 | method             | (optional) The http method of the request. Express [app.METHOD](https://expressjs.com/en/api.html#app.METHOD) supported routing methods are all valid               |
 | htmlTagAttrs       | (optional) Dom attributes of <Html> tag                                                                                                                             |
-| headElement        | (optional) A function called with current request that return a React element you want to render into the `<head>` tag when given path is matched                   |
-| bodyBottomElement  | (optional) A function called with current request that return a React element you want to render into the bottom of `<body>` tag when given path is matched         |
+| headElement        | (optional) A function called with current request that returns a React element you want to render into the `<head>` tag when the given path is matched              |
+| bodyBottomElement  | (optional) A function called with current request that returns a React element you want to render into the bottom of `<body>` tag when the given path is matched    |
 | middlewareChain    | (optional) An array of express middleware function                                                                                                                  |
 | responseStatusCode | (optional) The http status code of response (defaults to 200)                                                                                                       |

--- a/src/createServerRender.js
+++ b/src/createServerRender.js
@@ -35,9 +35,9 @@ export default function createServerRender({
    * @param {Object} options.dataSources GQL data sources object
    * @param {Object} options.context context object which will be shared across all resolvers
    * @param {Object} options.htmlTagAttrs dom attributes of html tag
-   * @param {ReactElement} options.appElement: Application main React Element
-   * @param {Function} options.headElement A function called with the current request that return a React Element which will be placed in the HTML <head>
-   * @param {Function} options.bodyBottomElement A function called with the current request that return a React Element which will be placed in the bottom of the HTML <body>
+   * @param {Function} options.appElement: A function called with the current request that returns a React Element which will be placed in the <body>
+   * @param {Function} options.headElement A function called with the current request that returns a React Element which will be placed in the <head>
+   * @param {Function} options.bodyBottomElement A function called with the current request that returns a React Element which will be placed in the bottom of the appElement
    * @param {Object} options.req Express request object
    * @param {Object} options.cache GQL data source cache config object - optional
    */
@@ -85,7 +85,11 @@ export default function createServerRender({
     });
 
     // wrapping main component with Apollo Provider
-    const app = <ApolloProvider client={client}>{appElement}</ApolloProvider>;
+    const app = (
+      <ApolloProvider client={client}>
+        {typeof appElement === "function" && appElement({ req })}
+      </ApolloProvider>
+    );
 
     return renderToStringWithData(app).then(content => {
       const initialState = client.extract();


### PR DESCRIPTION
### Implementation note: ###

To support component based router integration (`react-router` for example), we need to transform the `appElement` field of `route` model into a render function which will be called with current request so that the request object can be accessed by the application component when needed.

### Please note that this PR contains a breaking change ###

From now, appElement will be a render function instead of a React element

before:

```js
{
  appElement: <App />
}
```

after:

```js
{
  appElement: ({ req }) => <App />
}
```
