### PR TITLE
Feat(ServerRenderer): make headElement able to run GQL query

### DIFF
--- a/src/Html.js
+++ b/src/Html.js
@@ -8,14 +8,14 @@ import {
 const Html = ({
   content,
   initialState,
-  headElement,
+  head,
   bodyBottomElement,
   htmlTagAttrs = {},
   inlineStateNonce
 }) => {
   return (
     <html {...htmlTagAttrs}>
-      <head>{headElement}</head>
+      <head dangerouslySetInnerHTML={{ __html: head }} />
       <body>
         <div
           id={ROOT_CONTAINER_ID}


### PR DESCRIPTION
### Background ###

Sometimes we need to get data from the external data source by running GQL and use it to render head meta tags.

### Implementation note ###

- Wrapped `headElement` with `ApolloProvider` to make it able to perform GQL query