### PR TITLE
Fix: styled-component ssr FOUC issue

### DIFF
--- a/src/createServerRender.js
+++ b/src/createServerRender.js
@@ -102,11 +102,8 @@ export default function createServerRender({
       </ApolloProvider>
     );
 
-    const renderingHead = getDataFromTree(headWithApollo);
-    const renderingApp = renderToStringWithData(appWithApollo);
-
-    const head = await renderingHead;
-    const app = await renderingApp;
+    const app = await renderToStringWithData(appWithApollo);
+    const head = await getDataFromTree(headWithApollo);
 
     const initialState = client.extract();
     const html = (


### PR DESCRIPTION
**Root cause:**

Rendering `head` and `app` components concurrently will cause  failing `styled-component` server side styles gathering.

**Solution:**

Render `head` component right after `app` component finished its rendering job

**Screenshot:**

Before:

![Screen Shot 2020-03-17 at 3 48 13 PM](https://user-images.githubusercontent.com/1024985/76834002-5c703880-6867-11ea-9fe9-f9141d64a876.png)

After:

![Screen Shot 2020-03-17 at 3 50 01 PM](https://user-images.githubusercontent.com/1024985/76834018-642fdd00-6867-11ea-8663-28dce92cd915.png)
