### PR TITLE
fix: remove extra end after send

### DIFF
--- a/src/UniversalApp.js
+++ b/src/UniversalApp.js
@@ -58,7 +58,6 @@ const initServer = function(app, routes, apolloServerOptions, production) {
             .then(html => {
               res.status(responseStatusCode);
               res.send(html);
-              res.end();
             })
             .catch(error => {
               next(error);


### PR DESCRIPTION
One of our internal library uses [http-hooks](https://github.com/yahoo/http-hooks) to listen to `httpHooks:pre:end` for server side tracking. 

The extra call to `res.end()` will cause the listener to trigger twice, resulting undesirable errors in our logs. 

Seems `res.send()` will also end the response, so there's no need to explicitly call `res.end()`

Ref: 
- https://stackoverflow.com/questions/40701123/do-i-need-to-call-next-after-res-send
- https://medium.com/@punitkmr/use-of-res-json-vs-res-send-vs-res-end-in-express-b50688c0cddf