### PR TITLE
fix: Pass response prop to appElement

### DIFF
--- a/src/UniversalApp.js
+++ b/src/UniversalApp.js
@@ -47,6 +47,7 @@ const initServer = function(app, routes, apolloServerOptions, production) {
             headElement,
             bodyBottomElement,
             req,
+            res,
             cache: apolloServer.requestOptions.cache,
             dataSources:
               typeof dataSources === "function" ? dataSources() : null,

--- a/src/UniversalApp.js
+++ b/src/UniversalApp.js
@@ -38,7 +38,7 @@ const initServer = function(app, routes, apolloServerOptions, production) {
         headElement,
         bodyBottomElement,
         middlewareChain = [],
-        responseStatusCode = 200
+        responseStatusCode = DEFAULT_STATUS_CODE
       }) => {
         app[method.toLowerCase()](path, middlewareChain, (req, res, next) => {
           serverRender({

--- a/src/UniversalApp.js
+++ b/src/UniversalApp.js
@@ -1,7 +1,7 @@
 import { ApolloServer } from "apollo-server-express";
 
 import createServerRender from "./createServerRender";
-import { LIB_TAG } from "./config/constants";
+import { LIB_TAG, DEFAULT_STATUS_CODE } from "./config/constants";
 
 const initServer = function(app, routes, apolloServerOptions, production) {
   // mount apollo-server-express middleware
@@ -57,7 +57,12 @@ const initServer = function(app, routes, apolloServerOptions, production) {
                 : context
           })
             .then(html => {
-              res.status(responseStatusCode);
+              if (
+                res.statusCode === DEFAULT_STATUS_CODE &&
+                res.statusCode !== responseStatusCode
+              ) {
+                res.status(responseStatusCode);
+              }
               res.send(html);
             })
             .catch(error => {

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,3 +1,4 @@
 export const LIB_TAG = "universal-react-apollo";
 export const REHYDRATION_STATE_DATA_KEY = "__APOLLO_STATE__";
 export const ROOT_CONTAINER_ID = "app-root";
+export const DEFAULT_STATUS_CODE = 200;

--- a/src/createServerRender.js
+++ b/src/createServerRender.js
@@ -39,6 +39,7 @@ export default function createServerRender({
    * @param {Function} options.headElement A function called with the current request that returns a React Element which will be placed in the <head>
    * @param {Function} options.bodyBottomElement A function called with the current request that returns a React Element which will be placed in the bottom of the appElement
    * @param {Object} options.req Express request object
+   * @param {Object} options.res Express response object
    * @param {Object} options.cache GQL data source cache config object - optional
    */
   return async ({
@@ -49,7 +50,8 @@ export default function createServerRender({
     appElement,
     headElement,
     bodyBottomElement,
-    req
+    req,
+    res
   }) => {
     // initialize the data source, required for Apollo RESTDataSource
     for (const dataSource of Object.values(dataSources)) {
@@ -98,7 +100,7 @@ export default function createServerRender({
     // wrapping main component with Apollo Provider
     const appWithApollo = (
       <ApolloProvider client={client}>
-        {typeof appElement === "function" && appElement({ req })}
+        {typeof appElement === "function" && appElement({ req, res })}
       </ApolloProvider>
     );
 


### PR DESCRIPTION
Affiliate site like to return 404 status code when API return no result. So we like to use `res`(response) to control http status code. And the sample code would like bellow

  - StatusCodeProvider.js
```js
    const StatusCodeContext = createContext()

    export const useStatusCode = () => {
        const setStatusCode = useContext(StatusCodeContext) || (() => {})
        return setStatusCode
    }

    const StatusCodeProvider = ({ response = {}, children }) => {
        const setStatusCode = code => response.status?.(code)
        return <StatusCodeContext.Provider value={setStatusCode}>{children}</StatusCodeContext.Provider>
    }
```

  - routing.js
```js
    appElement: ({ req, res }) => (
        <StaticRouter location={req.url} context={{}}>
            <StyleSheetManager sheet={sheet.instance}>
                <StatusCodeProvider response={res}>{appComponent}</StatusCodeProvider>
            </StyleSheetManager>
        </StaticRouter>
      )
```

  - App.js
```js
    const setStatusCode = useStatusCode()
    if ((!loading && totalCount === 0) || searchProductError) {
        setStatusCode(404)
    }
```