### PR TITLE
add cors option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ This function will mount [apollo-server-express](https://github.com/apollographq
 | routes        | An array of route object (see data model section)                                                                                                                              | 
 | apolloOptions | [Apollo server configuration options](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#parameters)                                                          |
 | production    | (optional) Flag indicates that the universal app is running in production mode or not. We use this flag to decide to turn on or off `GQL playground`. Default value is `false` |
+| cors          | Cors options. Default value is `false`                                                                                                                                         |
 
 ### clientRender(appElement)
 

--- a/src/UniversalApp.js
+++ b/src/UniversalApp.js
@@ -3,14 +3,14 @@ import { ApolloServer } from "apollo-server-express";
 import createServerRender from "./createServerRender";
 import { LIB_TAG } from "./config/constants";
 
-const initServer = function(app, routes, apolloServerOptions, production) {
+const initServer = function(app, routes, apolloServerOptions, production, cors = false) {
   // mount apollo-server-express middleware
   const apolloServer = new ApolloServer({
     ...apolloServerOptions,
     uploads: false,
     playground: !production
   });
-  apolloServer.applyMiddleware({ app });
+  apolloServer.applyMiddleware({ app, cors });
 
   const {
     typeDefs,


### PR DESCRIPTION
Apollo server inserts `Access-Control-Allow-Origin: *` as the default CORS setting, need to override it explicitly.

Since we're using express, the cors option needs to be passed into applyMiddleware

Ref: 
- https://www.apollographql.com/docs/apollo-server/api/apollo-server/#applymiddleware
- https://github.com/apollographql/apollo-server/issues/1326
- https://github.com/apollographql/apollo-server/blob/version-2/packages/apollo-server/src/index.ts#L94